### PR TITLE
Updated REST project version number

### DIFF
--- a/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
+++ b/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
@@ -15,6 +15,9 @@
       <RepositoryType>Git</RepositoryType>
       <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
       <PackageRequireLicenseAcceptance>true</PackageRequireLicenseAcceptance>
+      <PackageReleaseNotes>
+        1.1.0 Support PATCH and PUT HTTP requests in IRestClient.
+      </PackageReleaseNotes>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
+++ b/Celigo.ServiceManager.NetSuite.REST/src/Celigo.ServiceManager.NetSuite.REST.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
       <TargetFramework>netcoreapp3.1</TargetFramework>
-      <Version>1.0.6</Version>
+      <Version>1.1.0</Version>
       <Authors>CloudExtend.io</Authors>
       <Company>Celigo, Inc.</Company>
       <Description>REST Client for NetSuite REST API and RESTlets</Description>


### PR DESCRIPTION
Updated the project version number for the Celigo.ServiceManager.NetSuite.REST project from 1.0.6 to 1.1.0. The version number update was missing from PR [#42 ](url).